### PR TITLE
Notify user when on wrong network

### DIFF
--- a/ui/components/Layout.js
+++ b/ui/components/Layout.js
@@ -29,6 +29,7 @@ import { useAccount } from '../lib/use-wagmi'
 import Logo from '../public/logo.svg'
 import ErrorCard from './ErrorCard'
 import { useErrorContext } from './ErrorProvider'
+import PreferredNetworkWrapper from './PreferredNetworkWrapper'
 
 const navigation = [
   {
@@ -115,7 +116,11 @@ export default function Layout({ children }) {
         <div className="drawer drawer-mobile w-full h-full grow max-h-screen flex-1">
           <input id="side-drawer" type="checkbox" className="drawer-toggle" />
           <div className="drawer-content flex flex-col overflow-auto">
-            {children}
+            <PreferredNetworkWrapper
+              preferredNetwork={process.env.NEXT_PUBLIC_CHAIN}
+            >
+              {children}
+            </PreferredNetworkWrapper>
           </div>
           <div className="drawer-side">
             <label

--- a/ui/components/PreferredNetworkWrapper.js
+++ b/ui/components/PreferredNetworkWrapper.js
@@ -1,0 +1,20 @@
+import { useNetwork } from 'wagmi'
+import SwitchNetworkBanner from './SwitchNetworkBanner'
+
+export default function PreferredNetworkWrapper({
+  children,
+  preferredNetwork,
+}) {
+  const [{ data: networkData }] = useNetwork()
+
+  return (
+    <>
+      {networkData.chain &&
+        networkData.chain?.name.toUpperCase() !=
+          preferredNetwork.toUpperCase() && (
+          <SwitchNetworkBanner newNetwork={preferredNetwork} />
+        )}
+      {children}
+    </>
+  )
+}

--- a/ui/components/SwitchNetworkBanner.js
+++ b/ui/components/SwitchNetworkBanner.js
@@ -1,5 +1,5 @@
 import { ExclamationCircleIcon } from '@heroicons/react/outline'
-import { useNetwork } from 'wagmi'
+import { useNetwork } from '../lib/use-wagmi'
 
 const chainIds = {
   mainnet: 1,

--- a/ui/components/SwitchNetworkBanner.js
+++ b/ui/components/SwitchNetworkBanner.js
@@ -1,0 +1,34 @@
+import { ExclamationCircleIcon } from '@heroicons/react/outline'
+import { useNetwork } from 'wagmi'
+
+const chainIds = {
+  mainnet: 1,
+  goerli: 5,
+}
+
+export default function SwitchNetworkBanner({ newNetwork }) {
+  const [{}, switchNetwork] = useNetwork()
+
+  const capitalized = (network) =>
+    network.charAt(0).toUpperCase() + network.slice(1)
+
+  return (
+    <div className="bg-white p-4 px-8 flex flex-col gap-4 md:flex-row justify-between md:items-center">
+      <div className="flex flex-col sm:flex-row gap-2 items-center">
+        <ExclamationCircleIcon className="h-6 w-6 text-red-500" />
+        Nation3 uses {capitalized(newNetwork)} as its preferred network.
+      </div>
+
+      {/* There's a small chance the wallet used won't support switchNetwork, in which case the user needs to manually switch */}
+      {/* Also check if we have specified a chain ID for the network */}
+      {switchNetwork && chainIds[newNetwork] && (
+        <div
+          className="btn btn-md btn-secondary normal-case font-medium"
+          onClick={() => switchNetwork(chainIds[newNetwork])}
+        >
+          Switch to {capitalized(newNetwork)}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/lib/use-wagmi.js
+++ b/ui/lib/use-wagmi.js
@@ -3,6 +3,7 @@ import {
   useConnect as _useConnect,
   useAccount as _useAccount,
   useBalance as _useBalance,
+  useNetwork as _useNetwork,
   useContract,
   useContractRead as _useContractRead,
   useContractWrite as _wagmiUseContractWrite,
@@ -17,6 +18,10 @@ export function useConnect() {
 
 export function useAccount(params) {
   return useHandleError(_useAccount(params))
+}
+
+export function useNetwork(params) {
+  return useHandleError(_useNetwork(params))
 }
 
 export function useBalance(params) {


### PR DESCRIPTION
## Changes
- Created `SwitchNetworkBanner` to prompt the user to update their network to whatever is specified on `NEXT_PUBLIC_CHAIN`
- Created wrapper component to display banner when user is not on the network specified on `NEXT_PUBLIC_CHAIN`
<img width="882" alt="Screen Shot 2022-05-02 at 6 52 16 PM" src="https://user-images.githubusercontent.com/17715009/166343939-f25e0ee3-a962-4167-b448-412a509bff30.png">

## Future Improvements
Changing the network results in side effect errors from other `wagmi` hooks. We should consider filtering the errors that are displayed so repetitive / uninformative ones aren't fed to the user.
<img width="882" alt="Screen Shot 2022-05-02 at 6 53 34 PM" src="https://user-images.githubusercontent.com/17715009/166344027-65dbc697-2a60-41a8-8220-74b6221841ff.png">
