### PR TITLE
Update Available Rewards

### DIFF
--- a/ui/lib/liquidity-rewards.js
+++ b/ui/lib/liquidity-rewards.js
@@ -3,6 +3,7 @@ import { lpRewardsContract, balancerLPToken } from '../lib/config'
 import LiquidityRewardsDistributor from '../abis/BoostedLiquidityDistributor.json'
 import { transformNumber } from './numbers'
 import {
+  useStaticCall,
   useBalance,
   useContractRead,
   useContractWrite,
@@ -20,9 +21,11 @@ export function useLiquidityRewards({ nationPrice, poolValue, address }) {
   const months = transformNumber(6, 'bignumber', 0)
 
   const [{ data: unclaimedRewards, loading: unclaimedRewardsLoading }] =
-    useContractRead(contractParams, 'getUnclaimedRewards', {
-      args: [address],
-      watch: true,
+    useStaticCall({
+      ...contractParams,
+      methodName: 'claimRewards',
+      defaultData: transformNumber(0, 'bignumber'),
+      throwOnRevert: false, // assumes a reverted transaction means no claimable rewards
       skip: !address,
     })
 

--- a/ui/lib/static-call.js
+++ b/ui/lib/static-call.js
@@ -1,0 +1,67 @@
+import { useState, useEffect } from 'react'
+import { useSigner, useContract } from 'wagmi'
+
+// Hook for calling a contract write method without executing, getting the result without changing state (and thus gas fees)
+export function useStaticCall({
+  addressOrName,
+  contractInterface,
+  methodName,
+  args,
+  defaultData,
+  skip = false,
+  genericErrorMessage = 'Error calling contract',
+}) {
+  args = args?.length === 0 ? undefined : args // args should be undefined if there are no arguments, make sure here
+
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [data, setData] = useState(defaultData)
+
+  const [{ data: signer, isError: signerError, isLoading: signerLoading }] =
+    useSigner()
+
+  const contract = useContract({
+    addressOrName: addressOrName,
+    contractInterface: contractInterface,
+    signerOrProvider: signer,
+  })
+
+  useEffect(async () => {
+    if (
+      skip ||
+      !contract?.callStatic[methodName] ||
+      signerLoading ||
+      signerError ||
+      !signer
+    ) {
+      return
+    }
+    try {
+      const result = args
+        ? await contract.callStatic[methodName](...args)
+        : await contract.callStatic[methodName]()
+      setData(result)
+      setLoading(false)
+    } catch (error) {
+      console.error(error)
+      setError({ ...error, message: genericErrorMessage })
+      setLoading(false)
+    }
+  }, [
+    skip,
+    addressOrName,
+    contractInterface,
+    methodName,
+    genericErrorMessage,
+    JSON.stringify(args),
+    signer,
+  ])
+
+  return [
+    { data, error, loading },
+    contract.callStatic[methodName],
+    signer,
+    signerLoading,
+    signerError,
+  ]
+}

--- a/ui/lib/static-call.js
+++ b/ui/lib/static-call.js
@@ -9,6 +9,7 @@ export function useStaticCall({
   args,
   defaultData,
   skip = false,
+  throwOnRevert = true, // set to false if you'd like a reverted txn to be ignored and use the default data
   genericErrorMessage = 'Error calling contract',
 }) {
   args = args?.length === 0 ? undefined : args // args should be undefined if there are no arguments, make sure here
@@ -27,13 +28,7 @@ export function useStaticCall({
   })
 
   useEffect(async () => {
-    if (
-      skip ||
-      !contract?.callStatic[methodName] ||
-      signerLoading ||
-      signerError ||
-      !signer
-    ) {
+    if (skip || !signer) {
       return
     }
     try {
@@ -43,8 +38,10 @@ export function useStaticCall({
       setData(result)
       setLoading(false)
     } catch (error) {
-      console.error(error)
-      setError({ ...error, message: genericErrorMessage })
+      if (throwOnRevert) {
+        console.error(error)
+        setError({ ...error, message: genericErrorMessage })
+      }
       setLoading(false)
     }
   }, [

--- a/ui/lib/use-wagmi.js
+++ b/ui/lib/use-wagmi.js
@@ -10,10 +10,16 @@ import {
   useSigner,
 } from 'wagmi'
 import { useErrorContext } from '../components/ErrorProvider'
+import { useStaticCall as _useStaticCall } from './static-call'
 import { useHandleError } from './use-handle-error'
 
 export function useConnect() {
   return useHandleError(_useConnect())
+}
+
+// custom extension of wagmi
+export function useStaticCall(params) {
+  return useHandleError(_useStaticCall(params))
 }
 
 export function useAccount(params) {


### PR DESCRIPTION
## Changes
- Creates a hook for making static calls to a contract (will not change state and are gas-free)
- Enables silencing reverted static calls and defaulting to specified data
- Calls `claimRewards` using new static call hook

## Note
When calling `claimRewards` with my own account, the transaction consistently reverted. I'm assuming the method is built to revert when there are no claimable rewards, saving a user from spending the gas if there's nothing to claim. To account for this, I've set the hook to silence reverts on `claimRewards` and default to `0`. **This needs to be tested with an account that has claimable rewards to verify this.**