### PR TITLE
Disable buttons when on wrong chain

### DIFF
--- a/ui/components/ActionButton.js
+++ b/ui/components/ActionButton.js
@@ -1,3 +1,4 @@
+import usePreferredNetwork from '../lib/use-preferred-network'
 import { useAccount } from '../lib/use-wagmi'
 import ActionNeedsTokenApproval from './ActionNeedsTokenApproval'
 
@@ -19,9 +20,15 @@ export default function ActionButton({
     const tx = await write()
     postAction && tx.hash && postAction()
   }
+  const { isPreferredNetwork } = usePreferredNetwork()
+
   return (
     <>
-      {!account ? (
+      {!isPreferredNetwork ? (
+        <button className={className} disabled>
+          Wrong Network
+        </button>
+      ) : !account ? (
         <label htmlFor="web3-modal" className={`${className} modal-button`}>
           {children}
         </label>

--- a/ui/components/Layout.js
+++ b/ui/components/Layout.js
@@ -117,11 +117,7 @@ export default function Layout({ children }) {
         <div className="drawer drawer-mobile w-full h-full grow max-h-screen flex-1">
           <input id="side-drawer" type="checkbox" className="drawer-toggle" />
           <div className="drawer-content flex flex-col overflow-auto">
-            <PreferredNetworkWrapper
-              preferredNetwork={process.env.NEXT_PUBLIC_CHAIN}
-            >
-              {children}
-            </PreferredNetworkWrapper>
+            <PreferredNetworkWrapper>{children}</PreferredNetworkWrapper>
           </div>
           <div className="drawer-side">
             <label

--- a/ui/components/PreferredNetworkWrapper.js
+++ b/ui/components/PreferredNetworkWrapper.js
@@ -1,16 +1,12 @@
-import networkToId from '../lib/networkToId'
-import { useNetwork } from '../lib/use-wagmi'
+import usePreferredNetwork from '../lib/use-preferred-network'
 import SwitchNetworkBanner from './SwitchNetworkBanner'
 
-export default function PreferredNetworkWrapper({
-  children,
-  preferredNetwork,
-}) {
-  const { activeChain } = useNetwork()
+export default function PreferredNetworkWrapper({ children }) {
+  const { isPreferredNetwork, preferredNetwork } = usePreferredNetwork()
 
   return (
     <>
-      {activeChain?.id && activeChain.id != networkToId(preferredNetwork) && (
+      {!isPreferredNetwork && (
         <SwitchNetworkBanner newNetwork={preferredNetwork} />
       )}
       {children}

--- a/ui/lib/use-preferred-network.js
+++ b/ui/lib/use-preferred-network.js
@@ -1,0 +1,21 @@
+import { useEffect } from 'react'
+import { useState } from 'react'
+import networkToId from './networkToId'
+import { useNetwork } from './use-wagmi'
+
+export default function usePreferredNetwork() {
+  const { activeChain } = useNetwork()
+  const preferredNetwork = process.env.NEXT_PUBLIC_CHAIN
+
+  const [isPreferredNetwork, setIsPreferredNetwork] = useState(false)
+
+  useEffect(() => {
+    if (activeChain?.id && activeChain?.id == networkToId(preferredNetwork)) {
+      setIsPreferredNetwork(true)
+    } else {
+      setIsPreferredNetwork(false)
+    }
+  }, [activeChain?.id])
+
+  return { isPreferredNetwork, preferredNetwork }
+}


### PR DESCRIPTION
Changes:
- Create `usePreferredNetwork` hook for reusability
- Disable `ActionButton` when on the wrong network