### PR TITLE
No need for padding hacks to keep scroll working on mobile

### DIFF
--- a/ui/components/HomeCard.tsx
+++ b/ui/components/HomeCard.tsx
@@ -10,7 +10,7 @@ export default function HomeCard({
 }: any) {
   return (
     <Link href={href} passHref>
-      <div className="card w-80 md:w-96 bg-base-100 shadow-md transition ease-in-out hover:-translate-y-1 cursor-pointer">
+      <div className="card sm:w-96 bg-base-100 shadow-md transition ease-in-out hover:-translate-y-1 cursor-pointer">
         <div className="card-body items-stretch items-center ">
           {icon}
           <h2 className="card-title text-center font-medium">{title}</h2>

--- a/ui/components/HomeCard.tsx
+++ b/ui/components/HomeCard.tsx
@@ -10,7 +10,7 @@ export default function HomeCard({
 }: any) {
   return (
     <Link href={href} passHref>
-      <div className="card sm:w-96 bg-base-100 shadow-md transition ease-in-out hover:-translate-y-1 cursor-pointer">
+      <div className="card bg-base-100 shadow-md transition ease-in-out hover:-translate-y-1 cursor-pointer">
         <div className="card-body items-stretch items-center ">
           {icon}
           <h2 className="card-title text-center font-medium">{title}</h2>

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -142,7 +142,11 @@ export default function Layout({ children }: any) {
           <input id="side-drawer" type="checkbox" className="drawer-toggle" />
           <div className="drawer-content fixed top-0 left-0 right-0 bottom-0 lg:static pt-24 lg:pt-0 z-0 max-h-screen">
             <div className="flex flex-col w-full h-full">
-              <PreferredNetworkWrapper>{children}</PreferredNetworkWrapper>
+              <div className="hero h-full">
+                <div className="hero-content">
+                  <PreferredNetworkWrapper>{children}</PreferredNetworkWrapper>
+                </div>
+              </div>
             </div>
           </div>
           <div className="drawer-side">

--- a/ui/components/Layout.tsx
+++ b/ui/components/Layout.tsx
@@ -113,8 +113,8 @@ export default function Layout({ children }: any) {
   return (
     <div className="mx-auto bg-n3bg font-display">
       <Script src="https://cdn.splitbee.io/sb.js" />
-      <div className="flex flex-col h-screen">
-        <div className="navbar bg-base-100 border-slate-100 border-b-2 py-0 pl-0 lg:hidden">
+      <div className="h-screen">
+        <div className="navbar bg-base-100 border-slate-100 border-b-2 py-0 pl-0 lg:hidden sticky z-10">
           <div className="navbar-start border-slate-100 pl-0">
             <div className="w-80 border-slate-100 py-4 box-content">
               <div className="pl-6 pt-2 cursor-pointer">
@@ -138,10 +138,12 @@ export default function Layout({ children }: any) {
           </div>
         </div>
 
-        <div className="drawer drawer-mobile w-full h-full grow max-h-screen flex-1">
+        <div className="drawer drawer-mobile">
           <input id="side-drawer" type="checkbox" className="drawer-toggle" />
-          <div className="drawer-content flex flex-col overflow-auto">
-            <PreferredNetworkWrapper>{children}</PreferredNetworkWrapper>
+          <div className="drawer-content fixed top-0 left-0 right-0 bottom-0 lg:static pt-24 lg:pt-0 z-0 max-h-screen">
+            <div className="flex flex-col w-full h-full">
+              <PreferredNetworkWrapper>{children}</PreferredNetworkWrapper>
+            </div>
           </div>
           <div className="drawer-side">
             <label

--- a/ui/components/MainCard.tsx
+++ b/ui/components/MainCard.tsx
@@ -7,31 +7,29 @@ export default function MainCard({
   gradientBg,
 }: any) {
   return (
-    <div className="hero h-full">
+    <>
       {!loading ? (
-        <div className="hero-content">
-          <div className="max-w-md md:max-w-xl">
-            <div
-              className={`card min-w-80 md:w-full bg-base-100 shadow-md overflow-visible ${
-                gradientBg && 'bg-gradient-to-r from-n3blue to-n3green'
-              }`}
-            >
-              <div className="card-body items-stretch items-center">
-                <h2
-                  className={`card-title text-center text-3xl font-medium mb-2 ${
-                    gradientBg && 'text-white'
-                  }`}
-                >
-                  {title}
-                </h2>
-                {children}
-              </div>
+        <div className="max-w-md md:max-w-xl">
+          <div
+            className={`card min-w-80 md:w-full bg-base-100 shadow-md overflow-visible ${
+              gradientBg && 'bg-gradient-to-r from-n3blue to-n3green'
+            }`}
+          >
+            <div className="card-body items-stretch items-center">
+              <h2
+                className={`card-title text-center text-3xl font-medium mb-2 ${
+                  gradientBg && 'text-white'
+                }`}
+              >
+                {title}
+              </h2>
+              {children}
             </div>
           </div>
         </div>
       ) : (
         <button className="btn btn-square btn-ghost btn-disabled bg-transparent loading"></button>
       )}
-    </div>
+    </>
   )
 }

--- a/ui/components/MainCard.tsx
+++ b/ui/components/MainCard.tsx
@@ -9,7 +9,7 @@ export default function MainCard({
   return (
     <div className="hero h-full">
       {!loading ? (
-        <div className="hero-content pb-24 lg:pb-2">
+        <div className="hero-content">
           <div className="max-w-md md:max-w-xl">
             <div
               className={`card min-w-80 md:w-full bg-base-100 shadow-md overflow-visible ${

--- a/ui/pages/citizen.tsx
+++ b/ui/pages/citizen.tsx
@@ -37,60 +37,56 @@ export default function Citizen() {
         <Confetti key={number.toString()} />
       ))}
       <Head title="Welcome, citizen" />
-      <div className="hero h-full">
-        <div className="hero-content">
-          {account && passportData?.id && passportData?.nft ? (
-            <div className="flex flex-col items-center justify-center">
-              <div
-                style={{
-                  width: window.innerWidth > 390 ? '390px' : '320px',
-                }}
-              >
-                <Card
-                  style={{
-                    width: window.innerWidth > 390 ? '390px' : '320px',
-                    height: window.innerWidth > 390 ? '450px' : '369px',
-                    cursor: 'pointer',
-                    position: 'relative',
-                  }}
-                  onClick={() => addConfetti()}
-                >
-                  <Image src={passportData.nft.image} layout="fill" />
-                </Card>
-              </div>
+      {account && passportData?.id && passportData?.nft ? (
+        <div className="flex flex-col items-center justify-center">
+          <div
+            style={{
+              width: window.innerWidth > 390 ? '390px' : '320px',
+            }}
+          >
+            <Card
+              style={{
+                width: window.innerWidth > 390 ? '390px' : '320px',
+                height: window.innerWidth > 390 ? '450px' : '369px',
+                cursor: 'pointer',
+                position: 'relative',
+              }}
+              onClick={() => addConfetti()}
+            >
+              <Image src={passportData.nft.image} layout="fill" />
+            </Card>
+          </div>
 
-              <div className="stats stats-vertical md:stats-horizontal shadow mt-20">
-                <a
-                  className="stat"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                  href="https://discord.gg/nation3"
-                >
-                  <div className="stat-title">Access gated channels on</div>
-                  <div className="stat-value text-indigo-500">Discord</div>
-                </a>
+          <div className="stats stats-vertical md:stats-horizontal shadow mt-20">
+            <a
+              className="stat"
+              rel="noopener noreferrer"
+              target="_blank"
+              href="https://discord.gg/nation3"
+            >
+              <div className="stat-title">Access gated channels on</div>
+              <div className="stat-value text-indigo-500">Discord</div>
+            </a>
 
-                <a
-                  className="stat"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                  href="https://vote.nation3.org"
-                >
-                  <div className="stat-title">Vote on</div>
-                  <div className="stat-value text-yellow-400">Snapshot</div>
-                </a>
-              </div>
-              <div className="mt-8 flex flex-col text-center justify-center">
-                <button onClick={() => signMessageAndDownloadPass()}>
-                  <Image src={AddToWallet} width={220} height={68} />
-                </button>
-              </div>
-            </div>
-          ) : (
-            <button className="btn btn-square btn-ghost btn-disabled btn-lg bg-transparent loading"></button>
-          )}
+            <a
+              className="stat"
+              rel="noopener noreferrer"
+              target="_blank"
+              href="https://vote.nation3.org"
+            >
+              <div className="stat-title">Vote on</div>
+              <div className="stat-value text-yellow-400">Snapshot</div>
+            </a>
+          </div>
+          <div className="mt-8 flex flex-col text-center justify-center">
+            <button onClick={() => signMessageAndDownloadPass()}>
+              <Image src={AddToWallet} width={220} height={68} />
+            </button>
+          </div>
         </div>
-      </div>
+      ) : (
+        <button className="btn btn-square btn-ghost btn-disabled btn-lg bg-transparent loading"></button>
+      )}
     </>
   )
 }

--- a/ui/pages/citizen.tsx
+++ b/ui/pages/citizen.tsx
@@ -38,7 +38,7 @@ export default function Citizen() {
       ))}
       <Head title="Welcome, citizen" />
       <div className="hero h-full">
-        <div className="hero-content pb-24 lg:pb-2">
+        <div className="hero-content">
           {account && passportData?.id && passportData?.nft ? (
             <div className="flex flex-col items-center justify-center">
               <div

--- a/ui/pages/index.tsx
+++ b/ui/pages/index.tsx
@@ -17,9 +17,8 @@ export default function Index() {
   return (
     <>
       <Head title="Home" />
-
       <div className="hero h-full">
-        <div className="hero-content flex-col pb-24">
+        <div className="hero-content flex-col">
           <h1 className="card-title text-center text-3xl font-semibold mb-2">
             Welcome to Nation3
             <Image src={flag} width={36} height={36} />

--- a/ui/pages/index.tsx
+++ b/ui/pages/index.tsx
@@ -17,99 +17,95 @@ export default function Index() {
   return (
     <>
       <Head title="Home" />
-      <div className="hero h-full">
-        <div className="hero-content flex-col">
-          <h1 className="card-title text-center text-3xl font-semibold mb-2">
-            Welcome to Nation3
-            <Image src={flag} width={36} height={36} />
-          </h1>
+      <div className="flex flex-col max-w-3xl">
+        <h1 className="card-title text-center text-3xl font-semibold mb-2">
+          Welcome to Nation3
+          <Image src={flag} width={36} height={36} />
+        </h1>
 
-          <p className="max-w-sm mb-8">
-            Nation3 is a sovereign cloud nation. We are building a community of
-            like-minded people creating a nation on the cloud.{' '}
-            <GradientLink text="Read more" href="https://nation3.org" />
-            <br />
-            <br />
-            Here you can perform on-chain operations related to the Nation3
-            communinity, such as...
-          </p>
+        <p className="mb-8">
+          Nation3 is a sovereign cloud nation. We are building a community of
+          like-minded people creating a nation on the cloud.{' '}
+          <GradientLink text="Read more" href="https://nation3.org" />
+          <br />
+          <br />
+          Here you can perform on-chain operations related to the Nation3
+          communinity, such as...
+        </p>
 
-          <Link href="/claim">
-            <a className="btn btn-lg btn-primary mb-1 normal-case font-medium">
-              Claim $NATION
-            </a>
-          </Link>
+        <Link href="/claim">
+          <a className="btn btn-lg btn-primary mb-1 normal-case font-medium">
+            Claim $NATION
+          </a>
+        </Link>
 
-          <p>and then...</p>
+        <p className="text-center">and then...</p>
 
-          <div className="grid xl:grid-cols-2 mt-2 gap-8">
-            <HomeCard
-              href="/lock"
-              icon={
-                <LockClosedIcon className="h-5 w-5 absolute right-8 text-n3blue" />
-              }
-              title="Get $veNATION"
-              linkText="Get $veNATION"
-            >
-              <p>
-                Lock your $NATION to obtain $veNATION and help govern the
-                Nation3 DAO. $veNATION will be required to mint the upcoming
-                passport NFTs to become a citizen.
-              </p>
-            </HomeCard>
+        <div className="grid xl:grid-cols-2 mt-2 gap-8">
+          <HomeCard
+            href="/lock"
+            icon={
+              <LockClosedIcon className="h-5 w-5 absolute right-8 text-n3blue" />
+            }
+            title="Get $veNATION"
+            linkText="Get $veNATION"
+          >
+            <p>
+              Lock your $NATION to obtain $veNATION and help govern the Nation3
+              DAO. $veNATION will be required to mint the upcoming passport NFTs
+              to become a citizen.
+            </p>
+          </HomeCard>
 
-            <HomeCard
-              href="/join"
-              icon={
-                <UserAddIcon className="h-5 w-5 absolute right-8 text-n3blue" />
-              }
-              title="Become a citizen"
-              linkText="Claim a passport"
-            >
-              <p>
-                Once you have $veNATION, you can claim a passport. Only 420
-                Genesis passports will be launched in the beginning.
-              </p>
-            </HomeCard>
+          <HomeCard
+            href="/join"
+            icon={
+              <UserAddIcon className="h-5 w-5 absolute right-8 text-n3blue" />
+            }
+            title="Become a citizen"
+            linkText="Claim a passport"
+          >
+            <p>
+              Once you have $veNATION, you can claim a passport. Only 420
+              Genesis passports will be launched in the beginning.
+            </p>
+          </HomeCard>
 
-            <HomeCard
-              href="/liquidity"
-              icon={
-                <CurrencyDollarIcon className="h-5 w-5 absolute right-8 text-n3blue" />
-              }
-              title="Earn LP rewards"
-              linkText="Provide liquidity"
-            >
-              <p>
-                Provide liquidity in the{' '}
-                <a
-                  href="https://app.balancer.fi/#/pool/0x0bf37157d30dfe6f56757dcadff01aed83b08cd600020000000000000000019a"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-n3blue"
-                >
-                  80% $NATION / 20% $ETH Balancer pool
-                </a>{' '}
-                and earn liquidity rewards. Boost your APY by $
-                {veNationRewardsMultiplier}x by having $veNATION.
-              </p>
-            </HomeCard>
+          <HomeCard
+            href="/liquidity"
+            icon={
+              <CurrencyDollarIcon className="h-5 w-5 absolute right-8 text-n3blue" />
+            }
+            title="Earn LP rewards"
+            linkText="Provide liquidity"
+          >
+            <p>
+              Provide liquidity in the{' '}
+              <a
+                href="https://app.balancer.fi/#/pool/0x0bf37157d30dfe6f56757dcadff01aed83b08cd600020000000000000000019a"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-n3blue"
+              >
+                80% $NATION / 20% $ETH Balancer pool
+              </a>{' '}
+              and earn liquidity rewards. Boost your APY by $
+              {veNationRewardsMultiplier}x by having $veNATION.
+            </p>
+          </HomeCard>
 
-            <HomeCard
-              href={`https://app.balancer.fi/#/trade/ether/${nationToken}`}
-              icon={
-                <PlusIcon className="h-5 w-5 absolute right-8 text-n3blue" />
-              }
-              title="Buy more $NATION"
-              linkText="Buy $NATION"
-            >
-              <p>
-                You can buy more $NATION and participate in liquidity rewards.
-                You can also lock your $NATION to get $veNATION to boost your
-                rewards, get a passport NFT, and govern the DAO.
-              </p>
-            </HomeCard>
-          </div>
+          <HomeCard
+            href={`https://app.balancer.fi/#/trade/ether/${nationToken}`}
+            icon={<PlusIcon className="h-5 w-5 absolute right-8 text-n3blue" />}
+            title="Buy more $NATION"
+            linkText="Buy $NATION"
+          >
+            <p>
+              You can buy more $NATION and participate in liquidity rewards. You
+              can also lock your $NATION to get $veNATION to boost your rewards,
+              get a passport NFT, and govern the DAO.
+            </p>
+          </HomeCard>
         </div>
       </div>
     </>


### PR DESCRIPTION
We had some very weird behavior resulting in all apps having to implement `pb-24` (bottom padding) or otherwise it would be impossible for users to reach the bottom part of the page on mobile. In general the scrolling behavior for mobile was a little bit hacky, needing a handful of Tailwind classes around multiple components to make it work. 

We also had some code duplicity since all pages had to have `hero` and `hero-content` divs for them to be correctly centered (both vertically and horizontally) on the page.

Now:
- Navbar is `sticky`
- No need for each page to have the nasty `pb-24` hack
- No need for each page to have `hero` and `hero-content`, they have been moved to `Layout`