### PR TITLE
chore: limit to one dependency update at the time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,4 @@ updates:
     directory: "/ui" # Location of package manifests
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 1


### PR DESCRIPTION
https://app.dework.xyz/nation3/develop-1?taskId=ef452308-d8bf-4394-bc2c-6c3a722e048c

Makes it easier to handle breaking changes.