### PR TITLE
Fix negative veNation estimation at lock

### DIFF
--- a/ui/components/TimeRange.tsx
+++ b/ui/components/TimeRange.tsx
@@ -37,7 +37,7 @@ export default function TimeRange({
         ) : (
           <>
             {' '}
-            <span>Now</span>
+            <span>{new Date(min).toISOString().substring(0, 10)}</span>
             <span></span>
             <span></span>
             <span></span>

--- a/ui/pages/lock.tsx
+++ b/ui/pages/lock.tsx
@@ -133,9 +133,7 @@ export default function Lock() {
   useEffect(() => {
     if (hasLock && veNationLock) {
       setMinMaxLockTime({
-        min: dateToReadable(
-          oneWeekOut
-        ),
+        min: dateToReadable(bigNumberToDate(veNationLock[1])),
         max: dateToReadable(dateOut(new Date(), { years: 4 })),
       })
       setCanIncrease({

--- a/ui/pages/lock.tsx
+++ b/ui/pages/lock.tsx
@@ -363,6 +363,7 @@ export default function Lock() {
                     min={minMaxLockTime.min}
                     max={minMaxLockTime.max}
                     onChange={(e: any) => {
+                      if(e.target.value < minMaxLockTime.min) { return false;}
                       setLockTime({
                         ...lockTime,
                         formatted: e.target.value


### PR DESCRIPTION
The simplest solution to the problem, set the minimum date on the slider to be the current lock date - will ave weird behaviour when working with locks within 100 days of 4 year period. Throwing this out there...