### PR TITLE
Fix negative venation estimation at lock

### DIFF
--- a/ui/components/TimeRange.tsx
+++ b/ui/components/TimeRange.tsx
@@ -37,7 +37,7 @@ export default function TimeRange({
         ) : (
           <>
             {' '}
-            <span>Now</span>
+            <span>{new Date(min).toISOString().substring(0, 10)}</span>
             <span></span>
             <span></span>
             <span></span>

--- a/ui/pages/lock.tsx
+++ b/ui/pages/lock.tsx
@@ -133,9 +133,7 @@ export default function Lock() {
   useEffect(() => {
     if (hasLock && veNationLock) {
       setMinMaxLockTime({
-        min: dateToReadable(
-          oneWeekOut
-        ),
+        min: dateToReadable(bigNumberToDate(veNationLock[1])),
         max: dateToReadable(dateOut(new Date(), { years: 4 })),
       })
       setCanIncrease({

--- a/ui/pages/lock.tsx
+++ b/ui/pages/lock.tsx
@@ -352,7 +352,7 @@ export default function Lock() {
                       Lock expiration date
                       <br />
                       <span className="text-xs">
-                        The minimum lock expiration date is the greater of one week from now or, if you have an existing lock, your existing lock expiration date. The maximum lock time is four years from now.
+                        { hasLock && veNationLock ? "Maximum four years from your existing lock expiration date." : "Minimum one week, maximum four years from now."}
                       </span>
                     </span>
                   </label>

--- a/ui/pages/lock.tsx
+++ b/ui/pages/lock.tsx
@@ -363,6 +363,7 @@ export default function Lock() {
                     min={minMaxLockTime.min}
                     max={minMaxLockTime.max}
                     onChange={(e: any) => {
+                      if(e.target.value < minMaxLockTime.min) { return false;}
                       setLockTime({
                         ...lockTime,
                         formatted: e.target.value

--- a/ui/pages/lock.tsx
+++ b/ui/pages/lock.tsx
@@ -132,8 +132,9 @@ export default function Lock() {
 
   useEffect(() => {
     if (hasLock && veNationLock) {
+      const originalLockDate = dateToReadable(bigNumberToDate(veNationLock[1]));
       setMinMaxLockTime({
-        min: dateToReadable(bigNumberToDate(veNationLock[1])),
+        min: originalLockDate,
         max: dateToReadable(dateOut(new Date(), { years: 4 })),
       })
       setCanIncrease({

--- a/ui/pages/lock.tsx
+++ b/ui/pages/lock.tsx
@@ -352,7 +352,7 @@ export default function Lock() {
                       Lock expiration date
                       <br />
                       <span className="text-xs">
-                        Minimum one week, maximum four years from now.
+                        The minimum lock expiration date is the greater of one week from now or, if you have an existing lock, your existing lock expiration date. The maximum lock time is four years from now.
                       </span>
                     </span>
                   </label>

--- a/ui/pages/lock.tsx
+++ b/ui/pages/lock.tsx
@@ -363,7 +363,9 @@ export default function Lock() {
                     min={minMaxLockTime.min}
                     max={minMaxLockTime.max}
                     onChange={(e: any) => {
-                      if(e.target.value < minMaxLockTime.min) { return false;}
+                      if (e.target.value < minMaxLockTime.min) {
+                        return false;
+                      }
                       setLockTime({
                         ...lockTime,
                         formatted: e.target.value


### PR DESCRIPTION
Again, maybe not exactly where we want to go, but this will prevent the manual entry of dates in earlier than the lock date meaning that now the slider, date control and input text are guarded.

Dework -https://app.dework.xyz/nation3/citizen-app-p?taskId=f614e270-4baf-4e1a-80d7-a6a9f3ad1234 