### PR TITLE
accounted for wantstoIncrease factor when trying to lock addition Nation

### DIFF
--- a/ui/pages/lock.tsx
+++ b/ui/pages/lock.tsx
@@ -116,7 +116,7 @@ export default function Lock() {
   const [wantsToIncrease, setWantsToIncrease] = useState(false)
 
   useEffect(() => {
-    if (hasLock && veNationLock) {
+    if (hasLock && veNationLock && !wantsToIncrease) {
       !lockAmount && setLockAmount(ethers.utils.formatEther(veNationLock[0]))
       const origTime = {
         value: veNationLock[1],


### PR DESCRIPTION
https://app.dework.xyz/bounties?taskId=0554bc64-e2b2-4161-90b5-75997aaf3891

UseEffect that sets the value for the lockTime was not accounting for whether the user was actively trying to increase it's value. 