### PR TITLE
Handle ENS error when there is no Web3 wallet

### DIFF
--- a/ui/lib/liquidity-rewards.ts
+++ b/ui/lib/liquidity-rewards.ts
@@ -36,7 +36,7 @@ export function useLiquidityRewards({ nationPrice, poolValue, address }: any) {
     {
       args: [address],
       watch: true,
-      enabled: address,
+      enabled: Boolean(address),
     }
   )
 
@@ -57,7 +57,7 @@ export function useLiquidityRewards({ nationPrice, poolValue, address }: any) {
     {
       args: [address],
       watch: true,
-      enabled: address,
+      enabled: Boolean(address),
     }
   )
 

--- a/ui/lib/passport-nft.ts
+++ b/ui/lib/passport-nft.ts
@@ -30,7 +30,7 @@ export function usePassportStatus(address: any) {
     {
       args: [address],
       watch: true,
-      enable: address,
+      enabled: Boolean(address),
     },
     false
   )


### PR DESCRIPTION
Fixing issue #54

Spent a while debugging this one :)

Found one spelling error 'enable'-> 'enabled'
And for some reason `wagmi.useContractRead` doesn't work properly when an `undefined` value is passed to `enabled` param instead of a boolean one

P.S. I'd suggest not using the production environment as cypress defaultUrl, but rather test against the local one