### PR TITLE
Bugfix: don't add errors indefinitely when wagmi hook fails

### DIFF
--- a/ui/components/ErrorProvider.tsx
+++ b/ui/components/ErrorProvider.tsx
@@ -1,16 +1,15 @@
-import { createContext, useContext, useState } from 'react'
-import React from 'react'
+import { createContext, useCallback, useContext, useState } from 'react'
 import { useNetwork } from 'wagmi'
 import networkToId from '../lib/network-id'
 
 const ErrorContext = createContext({} as any)
 
 function ErrorProvider({ children }: any) {
-  const [errors, setErrors] = useState([] as any)
+  const [errors, setErrors] = useState([] as any[])
   let [count, setCount] = useState(0)
   const { activeChain } = useNetwork()
 
-  const addError = (newErrors: any) => {
+  const addError = useCallback((newErrors: any) => {
     if (
       newErrors &&
       newErrors[0] &&
@@ -33,11 +32,11 @@ function ErrorProvider({ children }: any) {
             return
           }
         }
-        setErrors([{ key: count, ...error }, ...errors])
-        setCount(++count)
+        setErrors((prev) => [...prev, {key: prev.length, ...error}]);
+        setCount((prev) => prev + 1)
       }
     }
-  }
+  }, [activeChain?.id]);
 
   const removeError = (key: any) => {
     if (key > -1) {

--- a/ui/lib/use-handle-error.ts
+++ b/ui/lib/use-handle-error.ts
@@ -1,13 +1,13 @@
-import { useEffect } from 'react'
-import { useErrorContext } from '../components/ErrorProvider'
+import { useEffect } from 'react';
+import { useErrorContext } from '../components/ErrorProvider';
 
 // For some contract interactions, a reverted call is not an error
 export function useHandleError(object: any, throwOnRevert = true) {
-  const errorContext = useErrorContext()
+  const {addError} = useErrorContext()
   useEffect(() => {
     if (throwOnRevert && object.error) {
-      errorContext.addError([object.error])
+      addError([object.error])
     }
-  }, [object.error, throwOnRevert, errorContext])
+  }, [object.error, throwOnRevert, addError])
   return object
 }

--- a/ui/lib/use-handle-error.ts
+++ b/ui/lib/use-handle-error.ts
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { useErrorContext } from '../components/ErrorProvider';
+import { useEffect } from 'react'
+import { useErrorContext } from '../components/ErrorProvider'
 
 // For some contract interactions, a reverted call is not an error
 export function useHandleError(object: any, throwOnRevert = true) {


### PR DESCRIPTION
Task details: https://app.dework.xyz/nation3?taskId=4dddb358-a106-4d86-a0bd-3619dbfa5aab

This was a bug that I probably introduced here: https://github.com/nation3/app/pull/67/files#diff-a37b142e8f2323627230313ed4b7932bdf22bc797e0f33bb7cdbb98bff1a5e0cR11

Right now lots of stuff in the app isn't memoized properly, and since a lot of logic is `useEffect` driven, these kinds of bugs will appear. Ideally everything should be memoized, and all deps should be passed to e.g. `useCallback` and `useEffect`, and they won't trigger indefinitely because they're memoized. In this case, we fixed the lint warnings (which tell you to add all deps a hook uses), but that caused this issue because the stuff we put into the deps was not memoized and thus changed on each render.

Ofc more than happy to share more about best practices around memoization and TS I've learned over the years. Also, I'm more than happy to not get the bounty for this one since it was introduced by me in the other PR