### PR TITLE
update depricated config `[default]`

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 src = "src"
 out = "out"
 libs = ["lib"]


### PR DESCRIPTION
warning: Unknown section [default] found in foundry.toml. This notation for profiles has been deprecated and may result in the profile not being registered in future versions. Please use [profile.default] instead or run `forge config --fix`.

## Dework Task

<!--- Please link to the Dework task here. -->

## Related GitHub Issue

<!--- Please link to the GitHub issue here. -->

## Screenshots (if appropriate):

<!--- If your pull request changes the UI, please include before/after screenshots. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
