### PR TITLE
test: enable code coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  range: 40..80
+  round: down
+  precision: 2

--- a/.github/workflows/contracts_yarn.yml
+++ b/.github/workflows/contracts_yarn.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node-version: [14.x, 16.x, 18.x] # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        node-version: [16.x, 18.x] # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ui_goerli.yml
+++ b/.github/workflows/ui_goerli.yml
@@ -36,3 +36,7 @@ jobs:
     - run: yarn lint
     - run: yarn cypress:headless
     - run: yarn test
+    - run: yarn test:coverage
+    - uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true

--- a/.github/workflows/ui_goerli.yml
+++ b/.github/workflows/ui_goerli.yml
@@ -38,5 +38,5 @@ jobs:
     - run: yarn test
     - run: yarn test:coverage
     - uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: true
+      with:
+        fail_ci_if_error: true

--- a/.github/workflows/ui_mainnet.yml
+++ b/.github/workflows/ui_mainnet.yml
@@ -36,3 +36,4 @@ jobs:
     - run: yarn lint
     - run: yarn cypress:headless
     - run: yarn test
+    - run: yarn test:coverage

--- a/ui/README.md
+++ b/ui/README.md
@@ -58,3 +58,10 @@ Run unit tests:
 ```
 yarn test
 ```
+
+## Code Coverage
+
+Run code coverage:
+```
+yarn test:coverage
+```

--- a/ui/README.md
+++ b/ui/README.md
@@ -61,6 +61,8 @@ yarn test
 
 ## Code Coverage
 
+[![codecov](https://codecov.io/gh/nation3/app/branch/main/graph/badge.svg)](https://codecov.io/gh/nation3/app)
+
 Run code coverage:
 ```
 yarn test:coverage

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,7 +8,8 @@
     "lint": "next lint",
     "cypress": "cypress open",
     "cypress:headless": "cypress run",
-    "test": "jest"
+    "test": "jest",
+    "test:coverage": "jest --coverage --collectCoverageFrom=./lib/**"
   },
   "dependencies": {
     "@heroicons/react": "^1.0.5",

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,8 @@
     "cypress:headless": "cypress run",
     "e2e": "start-server-and-test dev http://localhost:42069 cypress",
     "e2e:headless": "start-server-and-test dev http://localhost:42069 cypress:headless",
-    "test": "jest"
+    "test": "jest",
+    "test:coverage": "jest --coverage --collectCoverageFrom=./lib/**"
   },
   "dependencies": {
     "@heroicons/react": "^1.0.5",


### PR DESCRIPTION
## Dework Task

https://app.dework.xyz/nation3/develop-1?taskId=d527f531-8dc2-4ec4-a025-3deb4c872ea5

## Related GitHub Issue

#96 

## Screenshots (if appropriate):

> ![Screen Shot 2022-08-24 at 4 22 10 PM](https://user-images.githubusercontent.com/95955389/186368381-88cd855a-186f-4b74-8c7b-ab6bb03a9039.png)

## How Has This Been Tested?

Tested running locally:

```
yarn test:coverage
```
```
yarn run v1.22.19
$ jest --coverage --collectCoverageFrom=./lib/**
 PASS  lib/network-id.test.ts (8.769 s)
 PASS  lib/numbers.test.ts (9.28 s)
--------------------------|---------|----------|---------|---------|-------------------
File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------------------|---------|----------|---------|---------|-------------------
All files                 |    6.96 |     9.03 |    4.34 |    6.81 |                   
 approve.ts               |       0 |        0 |       0 |       0 | 1-21              
 balancer.ts              |       0 |        0 |       0 |       0 | 1-57              
 config.ts                |       0 |        0 |     100 |       0 | 1-52              
 connectors.ts            |       0 |        0 |       0 |       0 | 1-53              
 liquidity-rewards.ts     |       0 |        0 |       0 |       0 | 2-224             
 merkle-drop.ts           |       0 |        0 |       0 |       0 | 1-71              
 nation-token.ts          |       0 |      100 |       0 |       0 | 1-5               
 network-id.ts            |   57.14 |       40 |     100 |   57.14 | 6,10-12           
 numbers.ts               |   64.28 |    54.54 |   66.66 |      68 | 4,19,32-35,41,49  
 passport-nft.ts          |       0 |        0 |       0 |       0 | 1-78              
 sign-agreement.ts        |       0 |      100 |       0 |       0 | 1-41              
 static-call.ts           |       0 |        0 |       0 |       0 | 1-65              
 use-handle-error.ts      |       0 |        0 |       0 |       0 | 1-12              
 use-preferred-network.ts |       0 |        0 |       0 |       0 | 1-20              
 use-wagmi.ts             |       0 |      100 |       0 |       0 | 1-59              
 ve-token.ts              |       0 |        0 |       0 |       0 | 1-95              
--------------------------|---------|----------|---------|---------|-------------------

Test Suites: 2 passed, 2 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        26.916 s
Ran all test suites.
✨  Done in 28.59s.
```

Tested [GitHub Actions](https://github.com/nation3/app/runs/7990625735?check_suite_focus=true):

> <img width="346" alt="Screen Shot 2022-08-24 at 4 39 14 PM" src="https://user-images.githubusercontent.com/95955389/186372096-b0ef667a-a8d0-4f5c-a56c-972c1f00afab.png">

Tested upload to [Codecov](https://app.codecov.io/gh/nation3/app):

> <img width="366" alt="Screen Shot 2022-08-24 at 4 41 31 PM" src="https://user-images.githubusercontent.com/95955389/186372730-a41df0ca-ef59-479e-90ce-fdff30225865.png">