### PR TITLE
test: set code coverage threshold (#104)

### DIFF
--- a/ui/jest.config.js
+++ b/ui/jest.config.js
@@ -1,5 +1,10 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'node'
+  testEnvironment: 'node',
+  coverageThreshold: {
+    global: {
+      lines: 6.80
+    }
+  }
 }


### PR DESCRIPTION
If coverage drops below 6.80%, `jest:coverage` will fail.

## Dework Task

https://app.dework.xyz/nation3/develop-1?taskId=f63f80f7-0d17-4dc4-aad0-62acd1951eb1

## Related GitHub Issue

closes #104

## Screenshots (if appropriate):

<!--- If your pull request changes the UI, please include before/after screenshots. -->

## How Has This Been Tested?

Tested setting the threshold higher than the current coverage.
