### PR TITLE
Fix uncontrolled input issue in lock page

### DIFF
--- a/ui/pages/lock.tsx
+++ b/ui/pages/lock.tsx
@@ -96,7 +96,7 @@ export default function Lock() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [veNationLock])
 
-  const [lockAmount, setLockAmount] = useState<string>()
+  const [lockAmount, setLockAmount] = useState<string>("")
 
   const oneWeekOut = useMemo(() => dateOut(new Date(), { days: 7 }), [])
 
@@ -354,7 +354,7 @@ export default function Lock() {
                             ? ethers.utils.formatEther(
                                 veNationLock[0].add(nationBalance?.value)
                               )
-                            : nationBalance?.formatted
+                            : (nationBalance?.formatted || '')
                         )
                         setWantsToIncrease(true)
                       }}


### PR DESCRIPTION
## Dework Task

https://app.dework.xyz/nation3/app-2?taskId=db483966-5a0f-44e0-ac3c-e40676c7ee9e

## Related GitHub Issue

Fixes https://github.com/nation3/app/issues/85

## How Has This Been Tested?

Go to http://localhost:42069/lock and type a number into the "Lock amount" field.

This issue was because we are passing `undefined` before which made the component uncontrolled, now these changes will pass an empty string instead
NOTE: also fixed the same issue when we click the `Max' Button
