### PR TITLE
chore: skip macos

### DIFF
--- a/.github/workflows/contracts_yarn.yml
+++ b/.github/workflows/contracts_yarn.yml
@@ -13,7 +13,7 @@ jobs:
         working-directory: contracts
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         node-version: [16.x, 18.x] # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Skip due to unstable builds (network issues)?