### PR TITLE
refactor: remove passport expiration from /join page (#131)

### DIFF
--- a/ui/pages/join.tsx
+++ b/ui/pages/join.tsx
@@ -10,7 +10,6 @@ import Confetti from '../components/Confetti'
 import GradientLink from '../components/GradientLink'
 import Head from '../components/Head'
 import MainCard from '../components/MainCard'
-import PassportExpiration from '../components/PassportExpiration'
 import {
     nationPassportRequiredBalance,
     nationToken,
@@ -20,7 +19,6 @@ import {
 } from '../lib/config'
 import { useNationBalance } from '../lib/nation-token'
 import { NumberType, transformNumber } from '../lib/numbers'
-import { usePassportExpirationDate } from '../lib/passport-expiration-hook'
 import { useClaimPassport, useHasPassport } from '../lib/passport-nft'
 import { storeSignature, useSignAgreement } from '../lib/sign-agreement'
 import { useAccount } from '../lib/use-wagmi'
@@ -99,8 +97,6 @@ export default function Join() {
     veNationBalanceLoading,
   ])
 
-  const passportExpirationDate = usePassportExpirationDate()
-
   return (
     <>
       <Head title="Become a citizen" />
@@ -172,7 +168,6 @@ export default function Join() {
               </div>
 
             </div>
-            <PassportExpiration date={passportExpirationDate} />
 
             {action.mint ? (
               <ActionButton


### PR DESCRIPTION
Improves UX/UI by not presenting irrelevant information to users who do not already hold a passport.

## Dework Task

https://app.dework.xyz/nation3/citizen-app-p?taskId=1e2d33dc-48bc-4d33-a0c1-7491c459f008

## Related GitHub Issue

closes #131

## Screenshots (if appropriate):

## Before

> <img width="621" alt="Screen Shot 2022-09-29 at 11 21 18 AM" src="https://user-images.githubusercontent.com/95955389/192933704-59ca653d-ccfc-4646-a8ca-64fb726f5752.png">

## After

> <img width="617" alt="Screen Shot 2022-09-29 at 11 39 29 AM" src="https://user-images.githubusercontent.com/95955389/192933719-8602ae30-beaf-401d-b934-f6fc802cca8f.png">

## How Has This Been Tested?

- [x] Goerli ETH accounts with 0 `$veNATION`, > 0 `$veNATION`, > 2 `$veNATION`
- [x] `yarn cypress:headless`
- [x] `yarn test:coverage`
- [x] Mainnet Vercel preview: https://app-n2jirr16w-nation3.vercel.app/join
