### PR TITLE
fix(liquidity): Display full amount of staked lp

### DIFF
--- a/ui/pages/liquidity.tsx
+++ b/ui/pages/liquidity.tsx
@@ -295,7 +295,7 @@ export default function Liquidity() {
               ) : (
                 <>
                   <p className="mb-4">
-                    Available to withdraw: <Balance balance={userDeposit} /> LP
+                    Available to withdraw: <Balance balance={userDeposit} decimals={18} /> LP
                     tokens
                   </p>
 


### PR DESCRIPTION
## Dework Task

Dework task: https://app.dework.xyz/nation3/app-2?taskId=9a6aaa46-bc87-4171-bda4-1649dd01b9f7

<!--- Please link to the Dework task here. -->

## Related GitHub Issue

Closes: #143 

<!--- Please link to the GitHub issue here. -->

## Screenshots (if appropriate):

<!--- If your pull request changes the UI, please include before/after screenshots. -->
### Before: 
<img width="606" alt="Screen Shot 2022-10-13 at 7 27 25 PM" src="https://user-images.githubusercontent.com/14836056/195653714-198a018b-c454-4213-869a-b9bcc0fb0006.png">

### After:

<img width="603" alt="Screen Shot 2022-10-13 at 7 28 47 PM" src="https://user-images.githubusercontent.com/14836056/195653799-66152191-8505-4aa0-b861-3b63a02eeeef.png">

## How Has This Been Tested?

- Deposit `$NATION` tokens into `$NATION` / `WETH` balancer pool and obtain LP tokens
- Stake LP tokens from previous step in `/liquidity` page
- Click on `Unstake` and view the `Available to withdraw: ` amount to see the full amount with 18 decimal places (ERC20). Full amount as described in [original issue](https://github.com/nation3/app/issues/143#issue-1407371634)
- Should be same amount as when clicking the `MAX` button.




<!--- Please describe in detail how you tested your changes. -->
