### PR TITLE
Fix broken Discord invite link on /citizen page

### DIFF
--- a/ui/pages/citizen.tsx
+++ b/ui/pages/citizen.tsx
@@ -79,7 +79,7 @@ export default function Citizen() {
                     className="btn btn-primary gap-2 flex-1"
                     rel="noopener noreferrer"
                     target="_blank"
-                    href="https://discord.gg/JGfcHKmRMB"
+                    href="https://discord.gg/nation3-690584551239581708"
                   >
                     <Image src={DiscordIcon} width={24} height={24} />
                     <span className="hidden xl:block">


### PR DESCRIPTION
## Dework Task

https://app.dework.xyz/nation3/open-bounties-95838?source=discord-dm&taskId=96ae2c73-86ec-430e-9d62-cfcabe853f98

## Related GitHub Issue

https://github.com/nation3/app/issues/182

## Screenshots (if appropriate):

<!--- If your pull request changes the UI, please include before/after screenshots. -->

## How Has This Been Tested?

Manual testing.
