### PR TITLE
Updated citizen.tsx

### DIFF
--- a/ui/pages/citizen.tsx
+++ b/ui/pages/citizen.tsx
@@ -79,7 +79,7 @@ export default function Citizen() {
                     className="btn btn-primary gap-2 flex-1"
                     rel="noopener noreferrer"
                     target="_blank"
-                    href="https://discord.gg/JGfcHKmRMB"
+                    href="https://discord.gg/nation3-690584551239581708"
                   >
                     <Image src={DiscordIcon} width={24} height={24} />
                     <span className="hidden xl:block">


### PR DESCRIPTION
Fix broken discord link

## Dework Task

<!--- [https://app.dework.xyz/bounties?taskId=96ae2c73-86ec-430e-9d62-cfcabe853f98]-->
https://app.dework.xyz/bounties?taskId=96ae2c73-86ec-430e-9d62-cfcabe853f98

## Related GitHub Issue

<!--- [https://github.com/nation3/app/issues/182]. -->
https://github.com/nation3/app/issues/182

## Screenshots (if appropriate):

<!--- If your pull request changes the UI, please include before/after screenshots. -->
  ![My image](https://i.ibb.co/S51H2VH/before-and-after.png)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
The problem of the issue that the link expired. I generated a new link which will never expire and without limit to invitation and add. I tested the link and it is working perfectly.  This is the link I changed: https://discord.com/invite/nation3-690584551239581708
As you can see here: 
![My image](https://i.ibb.co/8DQ98Lw/screenshot-discord-com-2023-09-01-20-54-42.png)

