### PR TITLE
Fix venation ux

### DIFF
--- a/ui/pages/lock.tsx
+++ b/ui/pages/lock.tsx
@@ -443,8 +443,9 @@ export default function Lock() {
                           <p className="text-red-400">
                             Warning: {veNationAmount} $veNATION will drop to{' '}
                             {parseFloat(veNationAmount) - 0.01} as time passes.
-                            Consider locking {parseFloat(veNationAmount) + 0.1}{' '}
-                            $veNATION if you need exactly {veNationAmount}.
+                            Consider locking {parseFloat(lockAmount) + 0.1}{' '}
+                            $NATION if you need exactly {veNationAmount}{' '}
+                            $veNATION.
                           </p>
                         )}
                     </>

--- a/ui/pages/lock.tsx
+++ b/ui/pages/lock.tsx
@@ -50,8 +50,8 @@ const calculateVeNation = ({
   time,
   lockTime,
   max,
-}: any) => {
-  if (!nationAmount) return 0
+}: any): string => {
+  if (!nationAmount) return '0'
 
   const vestingStart = calculateVestingStart({
     nationAmount,
@@ -114,6 +114,17 @@ export default function Lock() {
 
   const [canIncrease, setCanIncrease] = useState({ amount: true, time: true })
   const [wantsToIncrease, setWantsToIncrease] = useState(false)
+
+  const veNationAmount = calculateVeNation({
+    nationAmount: lockAmount && +lockAmount,
+    veNationAmount: transformNumber(
+      veNationBalance?.value || 0,
+      NumberType.number
+    ),
+    time: Date.parse(lockTime.formatted),
+    lockTime: Date.parse(new Date().toString()),
+    max: Date.parse(minMaxLockTime.max),
+  })
 
   useEffect(() => {
     if (hasLock && veNationLock && !wantsToIncrease) {
@@ -251,11 +262,10 @@ export default function Lock() {
                 <InformationCircleIcon className="h-24 w-24 text-n3blue" />
                 <span>
                   We suggest you to obtain at least{' '}
-                  {nationPassportRequiredBalance || 0 + 0.5} $veNATION if you
-                  want to mint a passport NFT, since $veNATION balance drops
-                  over time. If it falls below the required threshold, your
-                  passport can be revoked. You can always lock more $NATION
-                  later.
+                  {nationPassportRequiredBalance + 0.5} $veNATION if you want to
+                  mint a passport NFT, since $veNATION balance drops over time.
+                  If it falls below the required threshold, your passport can be
+                  revoked. You can always lock more $NATION later.
                 </span>
               </div>
             </div>
@@ -423,20 +433,21 @@ export default function Lock() {
                     }}
                   />
                   {wantsToIncrease ? (
-                    <p>
-                      Your final balance will be approx{' '}
-                      {calculateVeNation({
-                        nationAmount: lockAmount && +lockAmount,
-                        veNationAmount: transformNumber(
-                          veNationBalance?.value || 0,
-                          NumberType.number
-                        ),
-                        time: Date.parse(lockTime.formatted),
-                        lockTime: Date.parse(new Date().toString()),
-                        max: Date.parse(minMaxLockTime.max),
-                      })}{' '}
-                      $veNATION
-                    </p>
+                    <>
+                      <p>
+                        Your final balance will be approx {veNationAmount}{' '}
+                        $veNATION
+                      </p>
+                      {Number.isInteger(parseFloat(veNationAmount)) &&
+                        veNationAmount !== '0' && (
+                          <p className="text-red-400">
+                            Warning: {veNationAmount} $veNATION will drop to{' '}
+                            {parseFloat(veNationAmount) - 0.01} as time passes.
+                            Consider locking {parseFloat(veNationAmount) + 0.1}{' '}
+                            $veNATION if you need exactly {veNationAmount}.
+                          </p>
+                        )}
+                    </>
                   ) : (
                     ''
                   )}


### PR DESCRIPTION
A warning message is shown if the veNATION amount is an integer like 1.0 or 2.0 or 3.0. The warning message disappears if the veNATION amount is a decimal like 4.1 or 4.2.

## Dework Task

https://app.dework.xyz/nation3/open-bounties-95838?taskId=4e0eac8d-5173-4d8e-9de0-20833a8ef6f7

## Related GitHub Issue

https://github.com/nation3/app/issues/200

## Screenshots (if appropriate):

![image](https://github.com/nation3/app/assets/21131329/914a2cb9-1cb3-4ed5-89f9-8cead4292aa7)

